### PR TITLE
Implement simple combat system

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Echo of Cayael is a small text-based adventure prototype for the "Worlds Within" project. It combines simple combat with choose-your-own-path storytelling, all running entirely in the browser.
 
+The included combat system is intentionally lightweight. Encounters are resolved with randomized damage rolls and serve as a proof of concept rather than a complete RPG battle system.
+
 ## Getting Started
 
 1. Download or clone this repository.

--- a/game.js
+++ b/game.js
@@ -7,6 +7,10 @@ const state = {
   honor: 50
 };
 
+const enemies = {
+  shade: { name: 'wandering shade', health: 20 }
+};
+
 const scenes = {
   intro: {
     text: [
@@ -31,7 +35,27 @@ const scenes = {
     text: [
       'The barren land stretches before you, whispering of battles yet to come.'
     ],
-    choices: []
+    choices: [
+      { text: 'Seek out the lurking shade', next: 'battle' },
+      { text: 'Return to camp', next: 'intro' }
+    ]
+  },
+  battle: {
+    text: [
+      'A shadowy figure emerges from the gloom.'
+    ],
+    choices: [
+      { text: 'Fight', combat: 'shade', next: 'victory' },
+      { text: 'Flee', next: 'trail' }
+    ]
+  },
+  victory: {
+    text: [
+      'The shade dissipates, leaving silence behind.'
+    ],
+    choices: [
+      { text: 'Continue down the trail', next: 'trail' }
+    ]
   }
 };
 
@@ -41,6 +65,40 @@ function updateStats() {
   document.getElementById('momentum').textContent = state.momentum;
   document.getElementById('fatigue').textContent = state.fatigue;
   document.getElementById('honor').textContent = state.honor;
+}
+
+function startCombat(enemyKey, nextScene) {
+  const enemy = enemies[enemyKey];
+  if (!enemy) {
+    alert('Combat encounter missing enemy data.');
+    if (nextScene) renderScene(nextScene);
+    return;
+  }
+
+  let enemyHealth = enemy.health;
+  const log = [];
+
+  while (enemyHealth > 0 && state.health > 0) {
+    const playerDamage = Math.ceil(Math.random() * 6);
+    enemyHealth -= playerDamage;
+    log.push(`You strike the ${enemy.name} for ${playerDamage} damage.`);
+    if (enemyHealth <= 0) break;
+    const enemyDamage = Math.ceil(Math.random() * 4);
+    state.health -= enemyDamage;
+    log.push(`The ${enemy.name} hits you for ${enemyDamage}.`);
+  }
+
+  if (state.health <= 0) {
+    log.push('You were defeated.');
+  } else {
+    log.push(`You defeated the ${enemy.name}!`);
+  }
+
+  alert(log.join('\n'));
+  updateStats();
+  if (state.health > 0 && nextScene) {
+    renderScene(nextScene);
+  }
 }
 
 function renderScene(key) {
@@ -55,7 +113,13 @@ function renderScene(key) {
     const btn = document.createElement('button');
     btn.className = 'choice-button';
     btn.textContent = choice.text;
-    btn.addEventListener('click', () => renderScene(choice.next));
+    btn.addEventListener('click', () => {
+      if (choice.combat) {
+        startCombat(choice.combat, choice.next);
+      } else {
+        renderScene(choice.next);
+      }
+    });
     choiceContainer.appendChild(btn);
   });
 }


### PR DESCRIPTION
## Summary
- add a lightweight combat helper `startCombat`
- trigger combat from choices if a `combat` key exists
- include a basic enemy and encounter in the game data
- clarify in the README that the combat system is minimal

## Testing
- `node --check game.js`
- *(fails: ReferenceError due to browser-only globals when executed in Node)*

------
https://chatgpt.com/codex/tasks/task_e_6872dfc0e614832aa979f3f8b1778634