### PR TITLE
Add dynamic inventory handling

### DIFF
--- a/Echo of Cayeal.html
+++ b/Echo of Cayeal.html
@@ -30,11 +30,7 @@
       <span class="stat-value" id="fatigue">0</span></div>
     <div class="stat-item"><span class="stat-label">Honor:</span>
       <span class="stat-value" id="honor">50</span></div>
-    <div id="inventory"><div class="stat-label">Inventory:</div>
-      <div class="inventory-item">• Fallen Comrade's Mask</div>
-      <div class="inventory-item">• Infantry Blade</div>
-      <div class="inventory-item">• Meager Rations</div>
-    </div>
+    <div id="inventory"></div>
   </div>
   <script src="game.js"></script>
 </body>

--- a/game.js
+++ b/game.js
@@ -86,6 +86,7 @@ function updateStats() {
   updateInventory();
 }
 
+// Refresh the inventory list displayed in the stats panel
 function updateInventory() {
   const container = document.getElementById('inventory');
   if (!container) return;

--- a/game.js
+++ b/game.js
@@ -5,6 +5,7 @@ const state = {
   momentum: 10,
   fatigue: 0,
   honor: 50,
+  inCombat: false,
   inventory: [
     "Fallen Comrade's Mask",
     'Infantry Blade',
@@ -70,6 +71,18 @@ function updateStats() {
   document.getElementById('momentum').textContent = state.momentum;
   document.getElementById('fatigue').textContent = state.fatigue;
   document.getElementById('honor').textContent = state.honor;
+
+  const erDisplay = document.getElementById('er-display');
+  const momentumDisplay = document.getElementById('momentum-display');
+
+  if (state.inCombat) {
+    erDisplay.style.display = 'block';
+    momentumDisplay.style.display = 'block';
+  } else {
+    erDisplay.style.display = 'none';
+    momentumDisplay.style.display = 'none';
+  }
+
   updateInventory();
 }
 
@@ -86,6 +99,8 @@ function updateInventory() {
 }
 
 function startCombat(enemyKey, nextScene) {
+  state.inCombat = true;
+  updateStats();
   const enemy = enemies[enemyKey];
   if (!enemy) {
     alert('Combat encounter missing enemy data.');
@@ -113,6 +128,7 @@ function startCombat(enemyKey, nextScene) {
   }
 
   alert(log.join('\n'));
+  state.inCombat = false;
   updateStats();
   if (state.health > 0 && nextScene) {
     renderScene(nextScene);
@@ -140,6 +156,7 @@ function renderScene(key) {
     });
     choiceContainer.appendChild(btn);
   });
+  updateStats();
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/game.js
+++ b/game.js
@@ -4,7 +4,12 @@ const state = {
   er: 0,
   momentum: 10,
   fatigue: 0,
-  honor: 50
+  honor: 50,
+  inventory: [
+    "Fallen Comrade's Mask",
+    'Infantry Blade',
+    'Meager Rations'
+  ]
 };
 
 const enemies = {
@@ -65,6 +70,19 @@ function updateStats() {
   document.getElementById('momentum').textContent = state.momentum;
   document.getElementById('fatigue').textContent = state.fatigue;
   document.getElementById('honor').textContent = state.honor;
+  updateInventory();
+}
+
+function updateInventory() {
+  const container = document.getElementById('inventory');
+  if (!container) return;
+  container.innerHTML = '<div class="stat-label">Inventory:</div>';
+  state.inventory.forEach(item => {
+    const div = document.createElement('div');
+    div.className = 'inventory-item';
+    div.textContent = `\u2022 ${item}`;
+    container.appendChild(div);
+  });
 }
 
 function startCombat(enemyKey, nextScene) {


### PR DESCRIPTION
## Summary
- add `inventory` array to game state
- populate `#inventory` dynamically via new `updateInventory` function
- invoke `updateInventory` from `updateStats`
- strip hardcoded inventory items from HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872e8416da4832abb32c2a5d23b051a