### PR TITLE
Fix stats update timing in renderScene

### DIFF
--- a/game.js
+++ b/game.js
@@ -122,6 +122,7 @@ function renderScene(key) {
     });
     choiceContainer.appendChild(btn);
   });
+  updateStats();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- refresh player stats whenever a scene is rendered

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6872e844649c832a9f74317e2fd62891